### PR TITLE
Fix Xterm size by upgrading xterm-addon-fit.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,9 +35,9 @@
     "socket.io-client": "^4.5.1",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0",
-    "xterm": "^5.0.0",
-    "xterm-addon-fit": "^0.6.0",
-    "xterm-addon-serialize": "^0.8.0"
+    "xterm": "~5.3.0",
+    "xterm-addon-fit": "~0.8.0",
+    "xterm-addon-serialize": "~0.11.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.13.14",


### PR DESCRIPTION
The size of Xterm on the [CLI page](https://lab.flipper.net/cli) was not full size. This was caused by a version mismatch between xterm and the addon, there were some [internal API changes](https://github.com/xtermjs/xterm.js/commit/22e8a2f8e7a8f6886effe22a6fa8705c1b29f6e4).

Now the version of Xterm is pinned to the latest version [5.3.0](https://github.com/xtermjs/xterm.js/releases/tag/5.3.0), with compatible versions of the addons.